### PR TITLE
Bug fix: Make sure arg of max is not an empty sequence

### DIFF
--- a/helper_classes.py
+++ b/helper_classes.py
@@ -15,7 +15,7 @@ class BigramsConfig:
 
 
 class ConfigSpecificResults:
-    """The data for one or multiple [`BigramConfg`]s"""
+    """The data for one or multiple [`BigramsConfig`]s"""
 
     def __init__(self, name: str, weight: float, bigrams: tuple):
         self.name = name

--- a/main.py
+++ b/main.py
@@ -1054,7 +1054,8 @@ def printLayoutData(layout: str, placing: int = None, name: str = None) -> None:
     lineToPrint += 1
 
     configSpecificData = getConfigSpecificData(layout)
-    maxVisNameLen = max(len(i.name) for i in configSpecificData if i.name != 'All')
+    visNameLen = [len(i.name) for i in configSpecificData if i.name != 'All']
+    maxVisNameLen = max(visNameLen) if visNameLen else 0
     asciiArray = getAsciiArray()
     for data in configSpecificData:
         try:


### PR DESCRIPTION
When I comment out the English and French `BigramsConfig`s and set the weight for German to 100% and reduce the `NR_OF_BEST_LAYOUTS` to 50, the optimizer crashes with this error message:

```
Traceback (most recent call last):
  File "/media/home/max/repos/8vim_keyboard_layout_calculator/main.py", line 1106, in <module>
    main()
  File "/media/home/max/repos/8vim_keyboard_layout_calculator/main.py", line 271, in main
    showDataInTerminal(finalLayoutList, finalScoresList, customLayouts)
  File "/media/home/max/repos/8vim_keyboard_layout_calculator/main.py", line 927, in showDataInTerminal
    printLayoutData(layout, placing=idx+1)
  File "/media/home/max/repos/8vim_keyboard_layout_calculator/main.py", line 1057, in printLayoutData
    maxVisNameLen = max(len(i.name) for i in configSpecificData if i.name != 'All')
ValueError: arg is an empty sequence
```

### Changes in this pull request:

* Prevent this error by checking if the sequence passed to `max()` is empty.
* Fix a typo.