### PR TITLE
Improve performance with cffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,12 +13,7 @@ git clone https://github.com/Glitchy-Tozier/8vim_keyboard_layout_calculator.git
 3. Open `config.py` and edit the config-parameters to match your language. The most important ones are:
     - `BIGRAMS_CONFIGS`
     - `NR_OF_BEST_LAYOUTS` (has a big impact on speed)
-4. Optional: For much faster execution times, the bottleneck functions have been rewritten in C. Compile them (only once) like this:
-   ```sh
-   (cd cffi && pypy3 cffi_extension_build.py)
-   ```
-   This requires a C compiler to be installed. Set `USE_CFFI` in `config.py` to `True`.
-5. Start the script:
+4. Start the script:
     - _(Install a recent version of [Python](https://www.python.org/))_
     - Navigate to this project's root directory and run the script.
 
@@ -30,6 +25,8 @@ If for whatever reason you can't use pypy, to at least benefit from *some* speed
 ```sh
 python3 main.py
 ```
+
+Optional: For much faster execution times, the bottleneck functions have been rewritten in C. If you want to use them, follow [these instructions](cffi/README.md).
 
 ### Compatibility
 #### Windows

--- a/README.md
+++ b/README.md
@@ -13,7 +13,12 @@ git clone https://github.com/Glitchy-Tozier/8vim_keyboard_layout_calculator.git
 3. Open `config.py` and edit the config-parameters to match your language. The most important ones are:
     - `BIGRAMS_CONFIGS`
     - `NR_OF_BEST_LAYOUTS` (has a big impact on speed)
-4. Start the script:
+4. Optional: For much faster execution times, the bottleneck functions have been rewritten in C. Compile them (only once) like this:
+   ```sh
+   (cd cffi && pypy3 cffi_extension_build.py)
+   ```
+   This requires a C compiler to be installed. Set `USE_CFFI` in `config.py` to `True`.
+5. Start the script:
     - _(Install a recent version of [Python](https://www.python.org/))_
     - Navigate to this project's root directory and run the script.
 

--- a/cffi/README.md
+++ b/cffi/README.md
@@ -13,6 +13,7 @@ And you need to compile the extension. This can be done with:
 ```sh
 cd cffi
 pypy3 cffi_extension_build.py
+cd ..
 ```
 
 This will use a C compiler in the background. If you don't have one installed, install one and try again.

--- a/cffi/README.md
+++ b/cffi/README.md
@@ -1,0 +1,32 @@
+# CFFI extension for faster execution times
+
+The _8vim keyboard layout calculator_ calculates the scores of millions of layouts which takes time (around 13 minutes on a laptop with the default configuration using PyPy). When you try different configurations, you spend a lot of time waiting.
+
+For faster execution times, the two "bottleneck" functions `testSingleLayout` and `getTopScores` have been rewritten in C. See the article [Speed up Python with CFFI](https://maximilian-schillinger.de/articles/speed-up-python-with-cffi.html) for how these function were determined as bottlenecks.
+
+This "C extension" can be used in `main.py` thanks to [CFFI](https://cffi.readthedocs.io/en/latest/), the _C Foreign Function Interface for Python_. If you use the _PyPy_ interpreter, _cffi_ should be already installed. Otherwise it can be installed via `pip install cffi`. See [Installation and Status](https://cffi.readthedocs.io/en/latest/installation.html) for details.
+
+If you want to use the C extension, you need to enable it in the configuration file `config.py`: Set `USE_CFFI` to `True`.
+
+And you need to compile the extension. This can be done with:
+
+```sh
+cd cffi
+pypy3 cffi_extension_build.py
+```
+
+This will use a C compiler in the background. If you don't have one installed, install one and try again.
+
+If you want to use _CPython_ (the default Python interpreter), run `python3 cffi_extension_build.py` instead. It's important to use the same Python interpreter for compiling the C extension and running the calculator! This step is only necessary once (except when you change the C code in this folder).
+
+Then run the calculator as usual with:
+
+```sh
+pypy3 main.py
+```
+
+or
+
+```sh
+python3 main.py
+```

--- a/cffi/README.md
+++ b/cffi/README.md
@@ -8,26 +8,16 @@ This "C extension" can be used in `main.py` thanks to [CFFI](https://cffi.readth
 
 If you want to use the C extension, you need to enable it in the configuration file `config.py`: Set `USE_CFFI` to `True`.
 
-And you need to compile the extension. This can be done with:
+## Usage
 
-```sh
-cd cffi
-pypy3 cffi_extension_build.py
-cd ..
-```
+| 1. Decide on Interpreter         | pypy3<br>(recommended)                                 | python3                                                  |
+|:---------------------------------|--------------------------------------------------------|----------------------------------------------------------|
+| 2. Install package (Linux only?) | pypy3-dev                                              | python3-dev                                              |
+| 3. Get `cffi`                    | Included by default                                    | Run `pip install cffi`                                   |
+| 4. Build code                    | Run `cd cffi && pypy3 cffi_extension_build.py ; cd ..` | Run `cd cffi && python3 cffi_extension_build.py ; cd ..` |
+| 5. Start optimizer               | Run `pypy3 main.py`                                    | Run `python3 main.py`                                    |
 
-This will use a C compiler in the background. If you don't have one installed, install one and try again.
+Remarks:
 
-If you want to use _CPython_ (the default Python interpreter), run `python3 cffi_extension_build.py` instead. It's important to use the same Python interpreter for compiling the C extension and running the calculator! This step is only necessary once (except when you change the C code in this folder).
-
-Then run the calculator as usual with:
-
-```sh
-pypy3 main.py
-```
-
-or
-
-```sh
-python3 main.py
-```
+* Step 2: If there is no `pypy3-dev` (or `python3-dev`) package for your distribution (p.e. Arch Linux), just install `pypy3` (or `python`).
+* Step 4 will use a C compiler in the background. If you don't have one installed, install one (p.e. `gcc`, `clang` or `tcc`) and try again.

--- a/cffi/cffi_extension.c
+++ b/cffi/cffi_extension.c
@@ -3,7 +3,7 @@
 #include <stdlib.h>
 #include <string.h>
 
-double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
+double test_single_layout(char* layout, int layout_length, BigramC* bigrams,
                           int bigrams_count, double* score_list)
 {
 	int ascii_array[256] = {0};
@@ -13,7 +13,7 @@ double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
 
 	double score = 0.0;
 	for (int i = 0; i < bigrams_count; i++) {
-		Bigram bigram = bigrams[i];
+		BigramC bigram = bigrams[i];
 		int row = ascii_array[bigram.letter1AsciiCode];
 		int column = ascii_array[bigram.letter2AsciiCode];
 		score += bigram.frequency * score_list[row*32 + column];

--- a/cffi/cffi_extension.c
+++ b/cffi/cffi_extension.c
@@ -4,7 +4,7 @@
 #include <string.h>
 
 double test_single_layout(char* layout, int layout_length, BigramC* bigrams,
-                          int bigrams_count, double* score_list)
+                          int bigrams_count, double score_list[][32])
 {
 	int ascii_array[256] = {0};
 	for (int j = 0; j < layout_length; j++) {
@@ -16,7 +16,7 @@ double test_single_layout(char* layout, int layout_length, BigramC* bigrams,
 		BigramC bigram = bigrams[i];
 		int row = ascii_array[bigram.letter1AsciiCode];
 		int column = ascii_array[bigram.letter2AsciiCode];
-		score += bigram.frequency * score_list[row*32 + column];
+		score += bigram.frequency * score_list[row][column];
 	}
 	return score;
 }

--- a/cffi/cffi_extension.c
+++ b/cffi/cffi_extension.c
@@ -1,0 +1,19 @@
+#include "cffi_extension.h"
+
+double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
+                          int bigrams_count, double* score_list)
+{
+	int ascii_array[256] = {0};
+	for (int j = 0; j < layout_length; j++) {
+		ascii_array[(unsigned char)layout[j]] = j;
+	}
+
+	double score = 0.0;
+	for (int i = 0; i < bigrams_count; i++) {
+		Bigram bigram = bigrams[i];
+		int row = ascii_array[bigram.letter1AsciiCode];
+		int column = ascii_array[bigram.letter2AsciiCode];
+		score += bigram.frequency * score_list[row*32 + column];
+	}
+	return score;
+}

--- a/cffi/cffi_extension.c
+++ b/cffi/cffi_extension.c
@@ -3,14 +3,17 @@
 #include <stdlib.h>
 #include <string.h>
 
-double test_single_layout(char* layout, int layout_length, BigramC* bigrams,
-                          int bigrams_count, double score_list[][32])
-{
+double
+test_single_layout(char* layout, int layout_length, BigramC* bigrams,
+                   int bigrams_count, double score_list[][32]) {
+	// ascii_array is a map:
+	// index/key = numeric value of a character; value = position
 	int ascii_array[256] = {0};
 	for (int j = 0; j < layout_length; j++) {
 		ascii_array[(unsigned char)layout[j]] = j;
 	}
 
+	// calculate score: sum of the scores for every bigram
 	double score = 0.0;
 	for (int i = 0; i < bigrams_count; i++) {
 		BigramC bigram = bigrams[i];
@@ -21,6 +24,7 @@ double test_single_layout(char* layout, int layout_length, BigramC* bigrams,
 	return score;
 }
 
+// a pair of a layout and its score
 typedef struct ScoredLayout {
 	char* layout;
 	double score;
@@ -31,7 +35,8 @@ cmplayoutp(const void *p1, const void *p2) {
 	return ((ScoredLayout*)p1)->score > ((ScoredLayout*)p2)->score;
 }
 
-double average(double* array, long count) {
+static double
+average(double* array, long count) {
 	double sum = 0.0;
 	for (long i = 0; i < count; i++) {
 		sum += array[i];
@@ -39,7 +44,9 @@ double average(double* array, long count) {
 	return sum / (double)count;
 }
 
-double average_of_selected(double* array, long count, bool* indices, long selection_count) {
+// calculate average of all array entries i for which indices[i] is true
+static double
+average_of_selected(double* array, long count, bool* indices, long selection_count) {
 	double sum = 0.0;
 	for (long i = 0; i < count; i++) {
 		if (indices[i])
@@ -48,7 +55,9 @@ double average_of_selected(double* array, long count, bool* indices, long select
 	return sum / (double)selection_count;
 }
 
-void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of_best, int letters_per_layer, char** top_layouts, double* top_scores) {
+void
+get_top_scores(char** layouts, long layout_count, double* scores, int nr_of_best,
+               int letters_per_layer, char** top_layouts, double* top_scores) {
 	// Returns the best [whatever you set "nrOfBestPermutations" to] layouts with their scores.
 	// The LAST items of those lists should be the best ones.
 
@@ -56,6 +65,8 @@ void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of
 	if (nr_of_best > layout_count)
 		nr_of_best = layout_count;
 
+	// create array indices_to_keep on the heap because it's to large for the stack
+	// (for some function calls)
 	long array_size = sizeof(bool) * layout_count;
 	bool* indices_to_keep = malloc(array_size);
 	memset(indices_to_keep, true, array_size);
@@ -68,6 +79,8 @@ void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of
 		max_needed = letters_per_layer*2;
 	if (score_count > max_needed) {
 		while (score_count > max_needed) {
+			// calculate average of all values in the first iteration and
+			// average of all remaining values in the following iterations
 			double mean;
 			if (score_count == layout_count)
 				mean = average(scores, layout_count);
@@ -88,6 +101,8 @@ void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of
 		}
 	}
 
+	// create array of layout/score pairs on the heap to store the remaining layouts
+	// sorted in ascending order
 	ScoredLayout* scored_layouts = calloc(new_length, sizeof(ScoredLayout));
 	// Do this after the loop has finished.
 	// Get the remaining (best) scores using the filtered indices.
@@ -104,6 +119,8 @@ void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of
 	// Sort scores & indices. This is way faster thanks to the above while-loop
 	qsort(scored_layouts, new_length, sizeof(ScoredLayout), cmplayoutp);
 
+	// copy only the `nr_of_best` best layouts and scores to the output parameters
+	// `top_layouts` and `top_scores`
 	for (int i = 0; i < nr_of_best; i++) {
 		int j = new_length - nr_of_best + i;
 		top_layouts[i] = scored_layouts[j].layout;

--- a/cffi/cffi_extension.c
+++ b/cffi/cffi_extension.c
@@ -1,4 +1,7 @@
 #include "cffi_extension.h"
+#include <stdbool.h>
+#include <stdlib.h>
+#include <string.h>
 
 double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
                           int bigrams_count, double* score_list)
@@ -16,4 +19,94 @@ double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
 		score += bigram.frequency * score_list[row*32 + column];
 	}
 	return score;
+}
+
+typedef struct ScoredLayout {
+	char* layout;
+	double score;
+} ScoredLayout;
+
+static int
+cmplayoutp(const void *p1, const void *p2) {
+	return ((ScoredLayout*)p1)->score > ((ScoredLayout*)p2)->score;
+}
+
+double average(double* array, long count) {
+	double sum = 0.0;
+	for (long i = 0; i < count; i++) {
+		sum += array[i];
+	}
+	return sum / (double)count;
+}
+
+double average_of_selected(double* array, long count, bool* indices, long selection_count) {
+	double sum = 0.0;
+	for (long i = 0; i < count; i++) {
+		if (indices[i])
+			sum += array[i];
+	}
+	return sum / (double)selection_count;
+}
+
+void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of_best, int letters_per_layer, char** top_layouts, double* top_scores) {
+	// Returns the best [whatever you set "nrOfBestPermutations" to] layouts with their scores.
+	// The LAST items of those lists should be the best ones.
+
+	// Make sure we don't try to get more scores than actually exist
+	if (nr_of_best > layout_count)
+		nr_of_best = layout_count;
+
+	long array_size = sizeof(bool) * layout_count;
+	bool* indices_to_keep = malloc(array_size);
+	memset(indices_to_keep, true, array_size);
+
+	// BEFORE sorting the lists, make sure they're not unnecessarily large
+	long score_count = layout_count;
+	long new_length = score_count;
+	int max_needed = nr_of_best*3;
+	if (max_needed < letters_per_layer*2)
+		max_needed = letters_per_layer*2;
+	if (score_count > max_needed) {
+		while (score_count > max_needed) {
+			double mean;
+			if (score_count == layout_count)
+				mean = average(scores, layout_count);
+			else
+				mean = average_of_selected(scores, layout_count, indices_to_keep, new_length);
+			// Get all indices & scores that are above the mean of the remaining scores.
+			// This more than halves remaining scores.
+			for (long i = 0; i < layout_count; i++) {
+				if (indices_to_keep[i] && scores[i] < mean) {
+					indices_to_keep[i] = false;
+					new_length--;
+				}
+			}
+			if (new_length == score_count)
+				// If scores aren't filtered anymore, stop the loop
+				break;
+			score_count = new_length;
+		}
+	}
+
+	ScoredLayout* scored_layouts = calloc(new_length, sizeof(ScoredLayout));
+	// Do this after the loop has finished.
+	// Get the remaining (best) scores using the filtered indices.
+	int j = 0;
+	for (long i = 0; i < layout_count; i++) {
+		if (indices_to_keep[i]) {
+			scored_layouts[j].layout = layouts[i];
+			scored_layouts[j].score = scores[i];
+			j++;
+		}
+	}
+	free(indices_to_keep);
+
+	// Sort scores & indices. This is way faster thanks to the above while-loop
+	qsort(scored_layouts, new_length, sizeof(ScoredLayout), cmplayoutp);
+
+	for (int i = 0; i < nr_of_best; i++) {
+		int j = new_length - nr_of_best + i;
+		top_layouts[i] = scored_layouts[j].layout;
+		top_scores[i] = scored_layouts[j].score;
+	}
 }

--- a/cffi/cffi_extension.h
+++ b/cffi/cffi_extension.h
@@ -5,7 +5,7 @@ typedef struct Bigram {
 } BigramC;
 
 double test_single_layout(char* layout, int layout_length, BigramC* bigrams,
-                          int bigrams_count, double* score_list);
+                          int bigrams_count, double score_list[][32]);
 
 void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of_best,
                     int letters_per_layer, char** top_layouts, double* top_scores);

--- a/cffi/cffi_extension.h
+++ b/cffi/cffi_extension.h
@@ -4,8 +4,30 @@ typedef struct Bigram {
 	double frequency;
 } BigramC;
 
+/*
+ * Calculate score for given layout.
+ *
+ * @param[in] layout Layout of interest.
+ * @param[in] layout_length Byte count of layout.
+ * @param[in] bigrams Array of bigrams needed to calculate the layout score.
+ * @param[in] bigrams_count Count of bigrams.
+ * @param[in] score_list Nested array of scores for letter placements.
+ * @return Score for the given layout.
+ */
 double test_single_layout(char* layout, int layout_length, BigramC* bigrams,
                           int bigrams_count, double score_list[][32]);
 
+/*
+ * Sort layouts by score in ascending order and store the top `nr_of_best`
+ * layouts in `top_layouts` and the corresponding scores in `top_scores`.
+ *
+ * @param[in]  layouts Pointer to unsorted array of layouts.
+ * @param[in]  layout_count Number of layouts (and corresponding scores).
+ * @param[in]  scores Array of scores.
+ * @param[in]  nr_of_best Number of best layouts to keep.
+ * @param[in]  letters_per_layer Letters per layer, usually 8.
+ * @param[out] top_layouts Pointer to array to store best layouts (sorted).
+ * @param[out] top_scores Pointer to array to store best scores (sorted).
+ */
 void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of_best,
                     int letters_per_layer, char** top_layouts, double* top_scores);

--- a/cffi/cffi_extension.h
+++ b/cffi/cffi_extension.h
@@ -2,9 +2,9 @@ typedef struct Bigram {
 	int letter1AsciiCode;
 	int letter2AsciiCode;
 	double frequency;
-} Bigram;
+} BigramC;
 
-double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
+double test_single_layout(char* layout, int layout_length, BigramC* bigrams,
                           int bigrams_count, double* score_list);
 
 void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of_best,

--- a/cffi/cffi_extension.h
+++ b/cffi/cffi_extension.h
@@ -6,3 +6,6 @@ typedef struct Bigram {
 
 double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
                           int bigrams_count, double* score_list);
+
+void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of_best,
+                    int letters_per_layer, char** top_layouts, double* top_scores);

--- a/cffi/cffi_extension.h
+++ b/cffi/cffi_extension.h
@@ -1,0 +1,8 @@
+typedef struct Bigram {
+	int letter1AsciiCode;
+	int letter2AsciiCode;
+	double frequency;
+} Bigram;
+
+double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
+                          int bigrams_count, double* score_list);

--- a/cffi/cffi_extension_build.py
+++ b/cffi/cffi_extension_build.py
@@ -1,0 +1,22 @@
+from cffi import FFI
+ffibuilder = FFI()
+
+ffibuilder.cdef("""\
+typedef struct Bigram {
+    int letter1AsciiCode;
+    int letter2AsciiCode;
+    double frequency;
+} Bigram;
+double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
+                          int bigrams_count, double* score_list);
+""")
+
+ffibuilder.set_source("_cffi_extension",  # name of the output C extension
+"""
+    #include "cffi_extension.h"
+""",
+    sources=['cffi_extension.c'],
+    libraries=[])
+
+if __name__ == "__main__":
+    ffibuilder.compile(verbose=True)

--- a/cffi/cffi_extension_build.py
+++ b/cffi/cffi_extension_build.py
@@ -9,6 +9,8 @@ typedef struct Bigram {
 } Bigram;
 double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
                           int bigrams_count, double* score_list);
+void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of_best,
+                    int letters_per_layer, char** top_layouts, double* top_scores);
 """)
 
 ffibuilder.set_source("_cffi_extension",  # name of the output C extension

--- a/cffi/cffi_extension_build.py
+++ b/cffi/cffi_extension_build.py
@@ -1,17 +1,10 @@
 from cffi import FFI
 ffibuilder = FFI()
 
-ffibuilder.cdef("""\
-typedef struct Bigram {
-    int letter1AsciiCode;
-    int letter2AsciiCode;
-    double frequency;
-} Bigram;
-double test_single_layout(char* layout, int layout_length, Bigram* bigrams,
-                          int bigrams_count, double* score_list);
-void get_top_scores(char** layouts, long layout_count, double* scores, int nr_of_best,
-                    int letters_per_layer, char** top_layouts, double* top_scores);
-""")
+with open('cffi_extension.h') as f:
+    header = f.read()
+
+ffibuilder.cdef(header)
 
 ffibuilder.set_source("_cffi_extension",  # name of the output C extension
 """

--- a/config.py
+++ b/config.py
@@ -100,6 +100,12 @@ DEBUG_MODE = False
 # Use Multiprocessing (disable this when using `pypy3 main.py`)
 USE_MULTIPROCESSING = False
 
+# Use CFFI for better performance. Before running `pypy3 main.py`,
+# execute this to compile the C(FFI) extension:
+# `cd cffi && pypy3 cffi_extension_build.py`
+# (compiler like gcc or clang required)
+USE_CFFI = True
+
 # Symbol used for filling up layer 4. If your alphabet or your bigram-list for some reason contains "-", change "-" to something else.
 FILL_SYMBOL = '-'
 

--- a/config.py
+++ b/config.py
@@ -104,7 +104,7 @@ USE_MULTIPROCESSING = False
 # execute this to compile the C(FFI) extension:
 # `cd cffi && pypy3 cffi_extension_build.py`
 # (compiler like gcc or clang required)
-USE_CFFI = True
+USE_CFFI = False
 
 # Symbol used for filling up layer 4. If your alphabet or your bigram-list for some reason contains "-", change "-" to something else.
 FILL_SYMBOL = '-'

--- a/main.py
+++ b/main.py
@@ -29,7 +29,8 @@ if USE_CFFI:
               f"cd cffi && {interpreter} ./cffi_extension_build.py")
         sys.exit(1)
 
-    LINEAR_SCORE_LIST = list(itertools.chain.from_iterable(SCORE_LIST))
+    FFI_SCORE_LIST_ARRAYS = [ffi.new('double[32]', list(array)) for array in SCORE_LIST]
+    FFI_SCORE_LIST = ffi.new('double[][32]', FFI_SCORE_LIST_ARRAYS)
 
 
 def main():
@@ -779,7 +780,7 @@ def getLayoutScores(layouts: tuple, bigrams: tuple, prevScores=None) -> tuple:
         for k, layout in enumerate(layouts):
             permutatedLayoutBytes = layout.encode('latin1')
             scores[k] = _cffi_extension.lib.test_single_layout(
-                permutatedLayoutBytes, len(layout), ffiBigrams, nrBigrams, LINEAR_SCORE_LIST
+                permutatedLayoutBytes, len(layout), ffiBigrams, nrBigrams, FFI_SCORE_LIST
             )
     else:
         asciiArray = getAsciiArray()
@@ -925,7 +926,7 @@ def greedyOptimization(layouts: tuple, scores: array, info: InfoWithTime = None)
                 for i, permutatedLayout in enumerate(layoutPermutations):
                     permutatedLayoutBytes = permutatedLayout.encode('latin1')
                     permutatedScore = _cffi_extension.lib.test_single_layout(
-                        permutatedLayoutBytes, len(permutatedLayout), ffiBigrams, nrBigrams, LINEAR_SCORE_LIST
+                        permutatedLayoutBytes, len(permutatedLayout), ffiBigrams, nrBigrams, FFI_SCORE_LIST
                     )
                     if permutatedScore > score:
                         layout = permutatedLayout

--- a/main.py
+++ b/main.py
@@ -756,13 +756,7 @@ def getLayoutScores(layouts: tuple, bigrams: tuple, prevScores=None) -> tuple:
 
     # Test the flow of all the layouts.
     for k, layout in enumerate(layouts):
-        for j, letter in enumerate(layout):
-            asciiArray[ord(letter)] = j  # Fill up asciiArray
-
-        for bigram in bigrams: # Go through every bigram and see how well it flows.
-            firstLetterPlacement = asciiArray[bigram.letter1AsciiCode]
-            secondLetterPlacement = asciiArray[bigram.letter2AsciiCode]
-            scores[k] += bigram.frequency * SCORE_LIST[firstLetterPlacement][secondLetterPlacement]
+        scores[k] = testSingleLayout(layout, asciiArray, bigrams)
 
     if prevScores:
         # Add the previous layouts' scores. (which weren't tested here. It would be redundant.)

--- a/main.py
+++ b/main.py
@@ -23,8 +23,7 @@ if USE_CFFI:
         from cffi._cffi_extension import ffi
     except ModuleNotFoundError as e:
         implementation = platform.python_implementation()
-        if implementation == "CPython":
-            interpreter = "python3" if implementation == "CPython" else "pypy3"
+        interpreter = "python3" if implementation == "CPython" else "pypy3"
         print("Could not import _cffi_extension!\n"
               "Compile it with:\n"
               f"cd cffi && {interpreter} ./cffi_extension_build.py")

--- a/main.py
+++ b/main.py
@@ -26,7 +26,8 @@ if USE_CFFI:
         interpreter = "python3" if implementation == "CPython" else "pypy3"
         print("Could not import _cffi_extension!\n"
               "Compile it with:\n"
-              f"cd cffi && {interpreter} ./cffi_extension_build.py")
+              f"cd cffi && {interpreter} ./cffi_extension_build.py\n"
+              "(Or disable cffi usage by setting USE_CFFI in config.py to False.)")
         sys.exit(1)
 
     FFI_SCORE_LIST_ARRAYS = [ffi.new('double[32]', list(array)) for array in SCORE_LIST]

--- a/main.py
+++ b/main.py
@@ -921,32 +921,23 @@ def greedyOptimization(layouts: tuple, scores: array, info: InfoWithTime = None)
         info.set_status(f'{len(layouts)} layouts] [Greedy optimization')
     for layout, score in zip(layouts, deepcopy(scores)):
         optimizing = True
-        if USE_CFFI:
-            while optimizing is True:
-                layoutPermutations = performLetterSwaps(layout)
-                for i, permutatedLayout in enumerate(layoutPermutations):
+        while optimizing is True:
+            layoutPermutations = performLetterSwaps(layout)
+            for i, permutatedLayout in enumerate(layoutPermutations):
+                if USE_CFFI:
                     permutatedLayoutBytes = permutatedLayout.encode('latin1')
                     permutatedScore = _cffi_extension.lib.test_single_layout(
                         permutatedLayoutBytes, len(permutatedLayout), ffiBigrams, nrBigrams, FFI_SCORE_LIST
                     )
-                    if permutatedScore > score:
-                        layout = permutatedLayout
-                        score = permutatedScore
-                        break
-                    elif i+1 == len(layoutPermutations):
-                        optimizing = False
-        else:
-            while optimizing is True:
-                layoutPermutations = performLetterSwaps(layout)
-                for i, permutatedLayout in enumerate(layoutPermutations):
+                else:
                     permutatedScore = testSingleLayout(
                         permutatedLayout, asciiArray, bigrams)
-                    if permutatedScore > score:
-                        layout = permutatedLayout
-                        score = permutatedScore
-                        break
-                    elif i+1 == len(layoutPermutations):
-                        optimizing = False
+                if permutatedScore > score:
+                    layout = permutatedLayout
+                    score = permutatedScore
+                    break
+                elif i+1 == len(layoutPermutations):
+                    optimizing = False
         if layout not in optimizedLayouts:
             optimizedLayouts[layout] = score
     if DEBUG_MODE:


### PR DESCRIPTION
Out of curiosity, I have analyzed the performance of *8vim_keyboard_layout_calculator* and tested how much faster this script can be when the bottleneck functions are rewritten in C and called via `python-cffi`.

This way the optimizer runs more than double as fast. See my article [Speed up Python with CFFI](https://maximilian-schillinger.de/articles/speed-up-python-with-cffi.html) for details.

I don't know if it makes sense merging this. Updating the C code when the Python code changes is additional maintenance work. No problem for me if you decline this pull request. At least, interested users might find this PR and apply the changes locally.